### PR TITLE
(WIP) allow to set detail callback (i.e. to display it in modal)

### DIFF
--- a/ajax_datatable/static/ajax_datatable/js/utils.js
+++ b/ajax_datatable/static/ajax_datatable/js/utils.js
@@ -197,7 +197,7 @@ window.AjaxDatatableViewUtils = (function() {
     };
 
 
-    function _bind_row_tools(table, url, full_row_select)
+    function _bind_row_tools(table, url, full_row_select, detail_callback)
     {
         console.log('*** _bind_row_tools()');
 
@@ -231,9 +231,23 @@ window.AjaxDatatableViewUtils = (function() {
                     }
                 }
             });
-        }
-        else {
+        } else if(detail_callback) {
+            table.api().on('click', 'td.dataTables_row-tools .plus, td.dataTables_row-tools .minus', function(event) {
+                event.preventDefault();
+                var tr = $(this).closest('tr');
+                var row = table.api().row(tr);
+                if (row.child.isShown()) {
+                    row.child.hide();
+                    tr.removeClass('shown');
+                }
+                else {
+                    var data = _load_row_details(row.data(), url);
+                    detail_callback(data, tr);
+                    tr.addClass('shown');
+                }
+            });
 
+        } else {
             // Use "plus" and "minus" links to toggle row details
             table.api().on('click', 'td.dataTables_row-tools .plus, td.dataTables_row-tools .minus', function(event) {
                 event.preventDefault();
@@ -316,9 +330,9 @@ window.AjaxDatatableViewUtils = (function() {
     }
 
 
-    function after_table_initialization(table, data, url, full_row_select) {
+    function after_table_initialization(table, data, url, full_row_select, detail_callback) {
         console.log('*** after_table_initialization()');
-        _bind_row_tools(table, url, full_row_select);
+        _bind_row_tools(table, url, full_row_select, detail_callback);
         _setup_column_filters(table, data);
     }
 
@@ -464,7 +478,7 @@ window.AjaxDatatableViewUtils = (function() {
             var table = element.dataTable(options);
 
             _daterange_widget_initialize(table, data);
-            after_table_initialization(table, data, url, options.full_row_select);
+            after_table_initialization(table, data, url, options.full_row_select, options.detail_callback);
         })
     }
 


### PR DESCRIPTION
This is conceptual code, that allowed me to use Bootstrap 3 modals for table details with simple settings:
```javascript
                    detail_callback: function(data, tr){
                       $('.modal-body').html(data, 'details');
                       $('.modal').modal();
                    },
```

I am not sure how general the implementation of this should be, so I am leaving that for further discussion.
I can implement it to be quite concrete with just modal class to be set, or even more code could be leaved for users to implement.