### PR TITLE
Fix issue #27

### DIFF
--- a/ajax_datatable/static/ajax_datatable/js/utils.js
+++ b/ajax_datatable/static/ajax_datatable/js/utils.js
@@ -109,9 +109,19 @@ window.AjaxDatatableViewUtils = (function() {
     */
 
     function getCookie(name) {
+        var cookieValue = null;
         var value = '; ' + document.cookie,
             parts = value.split('; ' + name + '=');
-        if (parts.length == 2) return parts.pop().split(';').shift();
+        if (parts.length == 2) cookieValue = parts.pop().split(';').shift();
+        return cookieValue;
+    }
+
+    function getCSRFToken() {
+        var csrftoken = getCookie('csrftoken');
+        if (csrftoken == null) {
+            csrftoken = $('input[name=csrfmiddlewaretoken]').val();
+        }
+        return csrftoken;
     }
 
     function _setup_column_filters(table, data) {
@@ -345,7 +355,7 @@ window.AjaxDatatableViewUtils = (function() {
             url: url,
             data: data,
             dataType: 'json',
-            headers: {'X-CSRFToken': getCookie('csrftoken')}
+            headers: {'X-CSRFToken': getCSRFToken()}
         }).done(function(data, textStatus, jqXHR) {
 
             // https://datatables.net/manual/api#Accessing-the-API
@@ -403,7 +413,7 @@ window.AjaxDatatableViewUtils = (function() {
                           dataType: 'json',
                           cache: false,
                           crossDomain: false,
-                          headers: {'X-CSRFToken': getCookie('csrftoken')}
+                          headers: {'X-CSRFToken': getCSRFToken()}
                       }).done(function(data, textStatus, jqXHR) {
                           console.log('data rx: %o', data);
                           callback(data);


### PR DESCRIPTION
This PR fixes issues with setting CSRF token in Ajax calls.  Some Django sites have CSRF_COOKIE_HTTPONLY=True which caused getCookie('csrftoken') to return null, thereby never passing on the csrftoken to the server leading to a 403 error.

With this patch, it checks for `csrftoken` cookie and if it's null, it will look for a hidden input named `csrfmiddlewaretoken` in the document and returns the CSRF token if it's available. If neither is available, it will return null and could lead to a 403 error.