### PR TITLE
Fix search with a dropdown and with a booleanfield

### DIFF
--- a/ajax_datatable/columns.py
+++ b/ajax_datatable/columns.py
@@ -102,7 +102,7 @@ class Column(object):
     def render_column_value(self, obj, value):
 
         if self._allow_choices_lookup:
-            #return self._choices_lookup[value]
+            # return self._choices_lookup[value]
             return self.string_tags_in_case(self._choices_lookup.get(value, ''))
 
         if isinstance(value, datetime.datetime):
@@ -226,7 +226,7 @@ class ForeignColumn(Column):
 class ManyToManyColumn(ForeignColumn):
 
     def get_foreign_value(self, obj):
-        current_value = obj
+        current_value = obj # noqa
         m2m_name, m2m_field = self._field_path
 
         to_eval = f'obj.{m2m_name}_list'
@@ -242,6 +242,7 @@ class ManyToManyColumn(ForeignColumn):
             return ', '.join([str(self._choices_lookup.get(value, '')) for value in value_list])
 
         return ', '.join([str(value) for value in value_list])
+
 
 class ColumnLink(object):
 

--- a/ajax_datatable/filters.py
+++ b/ajax_datatable/filters.py
@@ -44,6 +44,16 @@ def build_column_filter(column_name, column_obj, column_spec, search_value, glob
     #     # search_filter = Q(**{query_param_name + '__in': [search_value, ]})
     #     raise Exception('Searching not supported for ManyToManyFields (yet)')
     #     pass
+    elif isinstance(column_obj.model_field, models.BooleanField):
+        query_param_name = column_obj.get_field_search_path()
+        if search_value in ['true', 'false']:
+            search_value = eval(search_value.capitalize())
+            search_filter = Q(**{query_param_name: search_value})
+        else:
+            if search_value in 'yes':
+                search_filter = Q(**{query_param_name: True})
+            elif search_value in 'no':
+                search_filter = Q(**{query_param_name: False})
     else:
         query_param_name = column_obj.get_field_search_path()
 

--- a/ajax_datatable/views.py
+++ b/ajax_datatable/views.py
@@ -232,6 +232,9 @@ class AjaxDatatableView(View):
                 cs['choices'] = choices if len(choices) > 0 else None
             # (3) Otherwise, just use the sequence of choices that has been supplied.
 
+            if choices and not [col for col in column_defs_ex if col['name'] == key and 'lookup_field' in col]:
+                cs['lookup_field'] = '__iexact'
+
             self.column_index[key] = {
                 'spec': cs,
                 'column': column,

--- a/example/backend/admin.py
+++ b/example/backend/admin.py
@@ -13,6 +13,7 @@ from .models import CustomPk
 class TagAdmin(admin.ModelAdmin):
     pass
 
+
 @admin.register(Tag2)
 class Tag2Admin(admin.ModelAdmin):
     pass

--- a/example/backend/models.py
+++ b/example/backend/models.py
@@ -21,6 +21,7 @@ TAG2_CHOICES = (
     ('new-age', 'New Age'),
 )
 
+
 class Tag2(models.Model):
     name = models.CharField(null=False, blank=False, max_length=256, choices=TAG2_CHOICES)
 

--- a/example/frontend/ajax_datatable_views.py
+++ b/example/frontend/ajax_datatable_views.py
@@ -99,7 +99,13 @@ class TrackAjaxDatatableView(AjaxDatatableView):
             'visible': True, 'choices': True, 'autofilter': True, },
         # {'name': 'tags', 'visible': True, 'searchable': False, },
         {'name': 'tags', 'm2m_foreign_field': 'tags__name', 'searchable': True, 'choices': True, 'autofilter': True, },
-        {'name': 'tags2', 'm2m_foreign_field': 'tags2__name', 'searchable': True, 'choices': True, 'autofilter': False, },
+        {
+            'name': 'tags2',
+            'm2m_foreign_field': 'tags2__name',
+            'searchable': True,
+            'choices': True,
+            'autofilter': False,
+        },
     ]
 
     @query_debugger


### PR DESCRIPTION
Does not make sense to use __icontains by default when we have a drop box :

![image](https://user-images.githubusercontent.com/5238993/142917444-1319d4ea-8f43-4e87-a1c8-c53bcebf8104.png)

Make more sense

![image](https://user-images.githubusercontent.com/5238993/142917703-ba687f15-c913-4532-be02-8500d2cbc14f.png)


Also fix searching a BooleanField :

![image](https://user-images.githubusercontent.com/5238993/142917792-f6ef81e2-9afc-4742-9a62-a62f55d95f68.png)

Same without a dropbox :

![image](https://user-images.githubusercontent.com/5238993/142918020-4684cc8f-b605-4637-b018-ecc06951c30b.png)