### PR TITLE
Fix column filter when savedstate is activated

### DIFF
--- a/ajax_datatable/static/ajax_datatable/js/utils.js
+++ b/ajax_datatable/static/ajax_datatable/js/utils.js
@@ -128,18 +128,24 @@ window.AjaxDatatableViewUtils = (function() {
 
         if (data.show_column_filters) {
 
+            var savedstate = table.api().state.loaded();
             var filter_row = '<tr class="datatable-column-filter-row">';
             $.each(data.columns, function(index, item) {
                 if (item.visible) {
                     if (item.searchable) {
                         var html = '';
+                        var initial_search_value = item.initialSearchValue ? item.initialSearchValue : ''
+                        if (!initial_search_value && savedstate) {
+                            var saved_search = savedstate.columns[index].search.search
+                            initial_search_value = saved_search ? saved_search : initial_search_value 
+                        }
                         if ('choices' in item && item.choices) {
 
                             // See: https://www.datatables.net/examples/api/multi_filter_select.html
                             var select = $('<select data-index="' + index.toString() + '"><option value=""></option></select>');
                             $(item.choices).each(function(index, choice) {
                                 var option = $("<option>").attr('value', choice[0]).text(choice[1]);
-                                if (choice[0] === item.initialSearchValue) {
+                                if (choice[0] === initial_search_value) {
                                     option.attr('selected', 'selected');
                                 }
                                 select.append(option);
@@ -151,7 +157,7 @@ window.AjaxDatatableViewUtils = (function() {
                                 .attr('type', 'text')
                                 .attr('data-index', index)
                                 .attr('placeholder', '...')
-                                .attr('value', item.initialSearchValue ? item.initialSearchValue : '')
+                                .attr('value', initial_search_value)
                             html = $('<div>').append(input).html();
                         }
                         if (item.className) {


### PR DESCRIPTION
If we enable state saving (https://datatables.net/examples/basic_init/state_save.html), on a refresh, the column will be filtered but it will not be visible.

IE, without this patch : 
![image](https://user-images.githubusercontent.com/5238993/146264685-3ebfbb3a-0cc9-47eb-aef1-116ac0df470f.png)


with this patch : 
![image](https://user-images.githubusercontent.com/5238993/146264613-91dc9039-2f11-45aa-8042-a982f18a722b.png)
