### PR TITLE
fix: include missing assignment exception

### DIFF
--- a/ajax_datatable/columns.py
+++ b/ajax_datatable/columns.py
@@ -202,10 +202,10 @@ class ForeignColumn(Column):
                         getattr(current_value, current_path_item)
                         for current_value in current_value.get_queryset()
                     ]
-                except AttributeError:
+                except (AttributeError, TypeError):
                     try:
                         current_value = [getattr(f, current_path_item) for f in current_value]
-                    except AttributeError:
+                    except (AttributeError, TypeError):
                         current_value = None
 
             if current_value is None:


### PR DESCRIPTION
 This is to prevent crashing in case of a subsequent relationship object is missing.  E.g. in case of relation if obj1__obj2__obj2field, obj1 or obj2 are missing